### PR TITLE
Update MMA8452.cpp

### DIFF
--- a/MMA8452.cpp
+++ b/MMA8452.cpp
@@ -433,9 +433,9 @@ void MMA8452::standby(bool standby)
 
 uint8_t MMA8452::read(uint8_t reg)
 {
-	uint8_t *buf = 0;
-	readMultiple(reg, buf, 1);
-	return *buf;
+	uint8_t buf = 0;
+	readMultiple(reg, &buf, 1);
+	return buf;
 }
 
 void MMA8452::write(uint8_t reg, uint8_t value)


### PR DESCRIPTION
The function 'read' in MMA8452.cpp:
uint8_t MMA8452::read(uint8_t reg) {
uint8_t *buf = 0;
readMultiple(reg, buf, 1);
return *buf;
}
defines an uninitialized pointer to uint8_t (the pointer does not point to a valid location in memory). This causes undefined behavior.
The function should be:
uint8_t MMA8452::read(uint8_t reg) {
uint8_t buf = 0;
readMultiple(reg, &buf, 1);
return buf;
}